### PR TITLE
Persist notifications on AJAX GET calls

### DIFF
--- a/Nethgui/Js/jquery.nethgui.notification.js
+++ b/Nethgui/Js/jquery.nethgui.notification.js
@@ -14,7 +14,7 @@
                 $('<ul />', {'class': 'fa-ul'}).appendTo(this.element);
             }
             $(document).on('ajaxSend.' + this.namespace, function (ev, jqxhr, settings) {
-                if(settings.url.match(/^\/js\//)) {
+                if(settings.type === 'GET') {
                     return;
                 }
                 $(self.element).find('li.notification').fadeOut(function () { $(this).remove() });


### PR DESCRIPTION
Only on POST we dismiss existing notifications. That means when User
submit a form or a page is completely reloaded.

This change is a generalization of the previous commit 9279a4589 which
avoids dismissing notifications during Calendar l10n queries.