### PR TITLE
Skip CSRF token rotation for AJAX requests

### DIFF
--- a/Nethgui/Controller/Request.php
+++ b/Nethgui/Controller/Request.php
@@ -41,6 +41,7 @@ class Request implements \Nethgui\Controller\RequestInterface, \Nethgui\Log\LogC
      */
     private $attributes = array(
         'format' => 'xhtml',
+        'isXhrRequest' => FALSE,
         'locale' => '',
         'localeDefault' => 'en-US',
         'isValidated' => FALSE,

--- a/Nethgui/Framework.php
+++ b/Nethgui/Framework.php
@@ -646,7 +646,7 @@ class Framework
             $log->error(sprintf("%s: CSRF token verification failed!", __CLASS__, $request->getAttribute('sourceOrigin'), $request->getAttribute('targetOrigin')));
             throw new \Nethgui\Exception\HttpException('Bad request', 400, 1504102184, new \RuntimeException("CSRF token verification failed", 1504102187));
         }
-        if($request->getUser()->isAuthenticated() && ! $request->isMutation() && $request->getAttribute('format') === 'xhtml' && $session instanceof \Nethgui\Utility\Session) {
+        if($request->getUser()->isAuthenticated() && ! $request->isMutation() && ! $request->getAttribute('isXhrRequest') && $request->getAttribute('format') === 'xhtml' && $session instanceof \Nethgui\Utility\Session) {
             $session->rotateCsrfToken();
             $session->checkHandoff();
         }
@@ -818,6 +818,7 @@ class Framework
         $request = new \Nethgui\Controller\Request($R);
         $request->setLog($this->dc['Log'])
             ->setAttribute('isMutation', $isMutation)
+            ->setAttribute('isXhrRequest', !empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
             ->setAttribute('format', $format)
             ->setAttribute('locale', $locale)
             ->setAttribute('localeDefault', $localeDefault)


### PR DESCRIPTION
The inline help pages are rendered as HTML but requested via AJAX call.
As additional condition to skip CSRF token rotation, check if the
request was submitted by an AJAX call.

NethServer/dev#5459